### PR TITLE
Updated readme with password for mount.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ vagrant up
 - Once it completed, you should be able to:
   - Access your local instance of Tatoeba at http://localhost:8080/
   - Run `vagrant ssh` to ssh to the machine.
-  - Use the script `mount.sh` (run it to get usage instructions) to mount any of the VM's directory on your host machine in order to modify files without ssh-ing to the VM.
+  - Use the script `mount.sh` (run it to get usage instructions) to mount any of the VM's directory on your host machine in order to modify files without ssh-ing to the VM. (Use 'vagrant' as the password if prompted after running `mount.sh`: `vagrant@127.0.0.1's password:`)
 
 ###Post-provisioning tasks
 You may want to perform certain tasks independently without having to re-provision the whole machine again. To do that you can use the following command:


### PR DESCRIPTION
This pull request addresses the issue as follows:

1. Clone the Imouto repo
2. Run `vagrant up`
3. Run `mount.sh`

A prompt for a password appears after step 3. I expected to see this password in the README. However, there is no mention of a password.

### The fix
I guessed the password (it was 'vagrant', the same as the username). I would like to include this password in the README in the hope that someone else would find it useful.