### PR TITLE
Fix trigger setup

### DIFF
--- a/ansible/roles/setup_database/tasks/create_db.yml
+++ b/ansible/roles/setup_database/tasks/create_db.yml
@@ -21,4 +21,4 @@
   - aros_acos
 - name: Install database triggers
 # This task requires mysql root for creating triggers
-  shell: find {{code_dir}}/docs/database/triggers -type f -exec cat {} \; | mysql -u root -p{{mysql_root_password}} {{mysql_db_name}}
+  shell: cat {{code_dir}}/docs/database/triggers/*.sql | mysql -u root -p{{mysql_root_password}} {{mysql_db_name}}


### PR DESCRIPTION
```
TASK [setup_database : Install database triggers] ******************************
fatal: [default]: FAILED! => {"changed": true, "cmd": "find /home/vagrant/Tatoeba/docs/database/triggers -type f -exec cat {} \\; | mysql -u root -ptatoeba tatoeba", "delta": "0:00:00.026687", "end": "2016-12-27 13:02:25.000610", "failed": true, "rc": 1, "start": "2016-12-27 13:02:24.973923", "stderr": "ERROR 1064 (42000) at line 176: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'DELIMITER | \nCREATE TRIGGER extend_sentences_lists_add AFTER INSERT ON `sentence' at line 1", "stdout": "", "stdout_lines": [], "warnings": []}
	to retry, use: --limit @/Users/halfdan/Projects/tatoeba/imouto/ansible/setup_database.retry
```

Running into the above when setting up triggers. This line seems needlessly complex anyway and just cat'ing SQL to mysql works fine.