### PR TITLE
Fix download URL

### DIFF
--- a/ansible/host_vars/default
+++ b/ansible/host_vars/default
@@ -38,7 +38,7 @@ mysql_db_name: tatoeba
 # Set this to 'local' if the csv's are already present in roles/codebase/files (sentences.csv, links.csv, tags_metadata.csv and tags_detailed.csv)
 # Set this to 'no' if you don't want to import data
 import_csv: 'download'
-download_url: http://tatoeba.org/files/downloads/
+download_url: http://downloads.tatoeba.org/exports/
 
 # Variables for Tatoeba's code and Cakephp
 # ----------------------------------------


### PR DESCRIPTION
When trying to run the `setup_database.yml` playbook, I would get the following errors (which this fixes):

```TASK [setup_database : Download packed csv's from tatoeba] *********************
failed: [default] (item=sentences.tar.bz2) => {"dest": "/tmp/sentences.tar.bz2", "failed": true, "item": "sentences.tar.bz2", "msg": "Request failed", "response": "HTTP Error 404: Not Found", "state": "absent", "status_code": 404, "url": "http://tatoeba.org/files/downloads/sentences.tar.bz2"}
failed: [default] (item=links.tar.bz2) => {"dest": "/tmp/links.tar.bz2", "failed": true, "item": "links.tar.bz2", "msg": "Request failed", "response": "HTTP Error 404: Not Found", "state": "absent", "status_code": 404, "url": "http://tatoeba.org/files/downloads/links.tar.bz2"}
failed: [default] (item=tag_metadata.csv) => {"dest": "/tmp/tag_metadata.csv", "failed": true, "item": "tag_metadata.csv", "msg": "Request failed", "response": "HTTP Error 404: Not Found", "state": "absent", "status_code": 404, "url": "http://tatoeba.org/files/downloads/tag_metadata.csv"}
failed: [default] (item=tags_detailed.tar.bz2) => {"dest": "/tmp/tags_detailed.tar.bz2", "failed": true, "item": "tags_detailed.tar.bz2", "msg": "Request failed", "response": "HTTP Error 404: Not Found", "state": "absent", "status_code": 404, "url": "http://tatoeba.org/files/downloads/tags_detailed.tar.bz2"}
	to retry, use: --limit @/Users/v-jacco/Desktop/imouto/ansible/setup_database.retry```