### PR TITLE
Add tatomecab dependencies

### DIFF
--- a/ansible/roles/setup_tatomecab/tasks/build_dict.yml
+++ b/ansible/roles/setup_tatomecab/tasks/build_dict.yml
@@ -2,7 +2,7 @@
 
 - name: Install dependencies for building dictionary
   apt:
-    name: libmecab-dev
+    name: ['make', 'mecab-utils', 'libmecab-dev']
     state: present
 
 - name: Modify dictionary with warifuri (this takes a long time)


### PR DESCRIPTION
Wenn I tried to rebuild the VM from scratch, the dictionary building step for tatomecab failed due to missing the `make` and `mecab-dict-index` commands. This PR adds the corresponding packages as dependencies.