### PR TITLE
Don't set executable bit of www-data files (fixes #55)

### DIFF
--- a/ansible/roles/update_code/tasks/main.yml
+++ b/ansible/roles/update_code/tasks/main.yml
@@ -52,7 +52,7 @@
   file:
     path: "{{ code_dir }}/{{ item }}"
     state: directory
-    mode: 0775
+    mode: ug=rw,o=r,a-x+X  # -x+X: no executable files, but can enter directories
     group: www-data
     recurse: yes
   with_items:


### PR DESCRIPTION
#55 was caused by recursively setting the file mode of several directories to `775`. The executable bit is necessary for directories to be traversable, but the recursion also applies it to all files in those directories. I don't think any of those files should ever be executed, so this PR clears the executable bit for all (`-x`) and only re-adds it for directories (`+X`). That does change the mode of the README files from `644` to `664`, but it seems like git only considers changes in the user permissions to be significant.