### PR TITLE
Update PHP version in handler for setup_php

### DIFF
--- a/ansible/roles/setup_php/handlers/main.yml
+++ b/ansible/roles/setup_php/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: reload php-fpm
   service:
-    name: php7.0-fpm
+    name: php7.3-fpm
     state: reloaded


### PR DESCRIPTION
The update to PHP 7.3 missed to update the handler in the `setup_php` role.