### PR TITLE
Update required minimum vagrant version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here are the basic requirements of the machine you’re using imouto from.
 * GNU/Linux, MacOS or Windows
 * Git (Windows users can use [Git for Windows](https://gitforwindows.org/))
 * VirtualBox 4.0 or later (via package manager or [generic binaries](https://www.virtualbox.org/wiki/Downloads))
-* Vagrant 1.7 or later (via package manager or [generic binaries](https://www.vagrantup.com/downloads.html))
+* Vagrant 2.2 or later (via package manager or [generic binaries](https://www.vagrantup.com/downloads.html))
 
 ## Installing a local instance
 


### PR DESCRIPTION
Today I was working on a machine with a very old vagrant version (1.8.1) and came across #67. I looked a little bit closer and noticed that triggers where [introduced in 2.1.0](https://www.vagrantup.com/docs/triggers).
But this version is still too old because we use the `ruby` option which was [introduced in 2.2.0](https://github.com/hashicorp/vagrant/blob/v2.2.9/CHANGELOG.md#220-october-16-2018)